### PR TITLE
Add explanation for bme.begin()

### DIFF
--- a/firmware/examples/bme280test/bme280test.ino
+++ b/firmware/examples/bme280test/bme280test.ino
@@ -36,6 +36,13 @@ void setup() {
   Serial.begin(9600);
   Serial.println(F("BME280 test"));
 
+/*
+ * Use .begin() to initialize the sensor, in this case !bme.begin() tests
+ * whether the sensor is found or not. If left out, any calls for finding 
+ * temperature/humidity/pressure will not return a value, nor will they fail!
+ * Returns 0 if it cannot be initialized, 1 otherwise.
+ */
+ 
   if (!bme.begin()) {
     Serial.println("Could not find a valid BME280 sensor, check wiring!");
     while (1);


### PR DESCRIPTION
Added a comment to explain the use of "bme.begin()". Even if it is run within an if statement to test whether the sensor is responding, .begin() needs to be called on the initiated sensor instance, otherwise no values will be returned from further calls.

(This may be obvious for someone with more experience, but when I went to integrate this into my own code, I didn't include the if statement, leading to confusion when calls to bme.readTemperature() returned 0.)
